### PR TITLE
Modified the getFqdnForIpAddress to fix the error returned when getting the fqdn of a ipv6 localhost address.

### DIFF
--- a/src_js/fqdn.js
+++ b/src_js/fqdn.js
@@ -6,7 +6,7 @@ const os = require('os');
 
 const localhostIdentifier = 'localhost';
 
-// Do a reverse lookup on the IP address and return the first FQDN.
+// Do a lookup service request on the IP address and return the first FQDN.
 function getFqdnForIpAddress(ipAddress, cb) {
   try {
     dns.lookupService(ipAddress, 0, function (err, hostname, service) {

--- a/src_js/fqdn.js
+++ b/src_js/fqdn.js
@@ -12,12 +12,12 @@ function getFqdnForIpAddress(ipAddress, cb) {
     dns.reverse(ipAddress, function(err, fqdns) {
       if (err) {
         if (err.code == "ENOTFOUND") {
-          dns.lookupService(ipAddress, 0, function (err, hostname, service) {
-              if (err) {
-                  console.log(err);
+          dns.lookupService(ipAddress, 0, function (lookupErr, hostname, service) {
+              if (lookupErr) {
+                  console.log(lookupErr);
                   return;
               }
-              cb(err, hostname);
+              cb(lookupErr, hostname);
           });
         } else {
           cb(err, fqdns);

--- a/src_js/fqdn.js
+++ b/src_js/fqdn.js
@@ -9,12 +9,24 @@ const localhostIdentifier = 'localhost';
 // Do a lookup service request on the IP address and return the first FQDN.
 function getFqdnForIpAddress(ipAddress, cb) {
   try {
-    dns.lookupService(ipAddress, 0, function (err, hostname, service) {
-        if (err) {
-            console.log(err);
-            return;
+    dns.reverse(ipAddress, function(err, fqdns) {
+      if (err) {
+        if (err.code == "ENOTFOUND") {
+          dns.lookupService(ipAddress, 0, function (err, hostname, service) {
+              if (err) {
+                  console.log(err);
+                  return;
+              }
+              cb(err, hostname);
+          });
+        } else {
+          cb(err, fqdns);
         }
-        cb(err, hostname);
+      } else if (fqdns[0].toLowerCase() === localhostIdentifier) {
+        getFqdn(localhostIdentifier, cb);
+      } else {
+        cb(err, fqdns[0]);
+      }
     });
   } catch (error) {
     cb(error, ipAddress);

--- a/src_js/fqdn.js
+++ b/src_js/fqdn.js
@@ -8,15 +8,17 @@ const localhostIdentifier = 'localhost';
 
 // Do a reverse lookup on the IP address and return the first FQDN.
 function getFqdnForIpAddress(ipAddress, cb) {
-  dns.reverse(ipAddress, function(err, fqdns) {
-    if (err) {
-      cb(err, fqdns);
-    } else if (fqdns[0].toLowerCase() === localhostIdentifier) {
-      getFqdn(localhostIdentifier, cb);
-    } else {
-      cb(err, fqdns[0]);
-    }
-  });
+  try {
+    dns.lookupService(ipAddress, 0, function (err, hostname, service) {
+        if (err) {
+            console.log(err);
+            return;
+        }
+        cb(err, hostname);
+    });
+  } catch (error) {
+    cb(error, ipAddress);
+  }
 }
 
 // Get the IP addresses for host. For each of the IP addresses, do a reverse


### PR DESCRIPTION
Modified the getFqdnForIpAddress to call the dns.lookupService function if dns.reverse returns the error code "ENOTFOUND" to allow for local ip addresses to resolve to their full host name correctly using the native apis in windows.